### PR TITLE
My free fix

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -46,6 +46,8 @@ int main() {
     test_ptr_2 = my_realloc(test_ptr_2, strlen(src7_2) + 1);
     strcpy(test_ptr_2, src7_2);
     printf("test_ptr_2_string after realloc: %s\n", test_ptr_2);
+    my_free(test_ptr_2);
+    printf("test_ptr_2_string after free: %s\n", test_ptr_2);
 
     return 0;
 }

--- a/src/my_malloc.c
+++ b/src/my_malloc.c
@@ -94,7 +94,7 @@ void my_free(void *ptr) {
     // Get the address of the block from the data pointer, then overwrite the 
     // data memory with a garbage pattern
     block_t *block = (block_t *)ptr - 1;
-    memset(ptr, 0xDE, block->size);
+    memset(ptr, 0, block->size);
     block->is_free = 1;
 }
 


### PR DESCRIPTION
Modified the `memset` function to set the free memory block to 0s instead of 0xDE. This makes it so when a different program prints the contents of the freed pointer, nothing gets printed. This aligns with the behavior of the real free.